### PR TITLE
Problems when using FAKE 4 with VS2017

### DIFF
--- a/FAKERunner/task.json
+++ b/FAKERunner/task.json
@@ -53,6 +53,14 @@
             "defaultValue": "",
             "required": "false",
             "helpMarkDown": "Other arguments passed to the FAKE script."
+        },
+        {
+            "name": "failOnStandardError",
+            "type": "boolean",
+            "label": "Fail on Standard Error",
+            "defaultValue": "false",
+            "required": false,
+            "helpMarkDown": "If this is true, this task will fail if any errors are written to the StandardError stream."
         }
     ],
     "execution": {


### PR DESCRIPTION
The problem is that the fake writes a message to stderr, which breaks the build. The opinion there is that I can simply add "ignore error outputs" to the batch target. But when I use the batch target, I'll loose all msbuild outputs. What I want is all the build outputs, but ignore this single stderr output.

But setting this option is not documented, so I try to ignore the error outputs of the build the same way as the original Batchscript target of TFS.