### PR TITLE
Multiple extensions

### DIFF
--- a/FAKE5.dev/package-lock.json
+++ b/FAKE5.dev/package-lock.json
@@ -5,7 +5,8 @@
     "@types/node": {
       "version": "7.0.69",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-7.0.69.tgz",
-      "integrity": "sha512-S5NC8HV6HnRipg8nC0j30TPl7ktXjRTKqgyINLNe8K/64UJUI8Lq0sRopXC0hProsV2F5ibj8IqPkl1xpGggrw=="
+      "integrity": "sha512-S5NC8HV6HnRipg8nC0j30TPl7ktXjRTKqgyINLNe8K/64UJUI8Lq0sRopXC0hProsV2F5ibj8IqPkl1xpGggrw==",
+      "dev": true
     },
     "@types/semver": {
       "version": "5.5.0",
@@ -18,6 +19,13 @@
       "integrity": "sha512-5fRLCYhLtDb3hMWqQyH10qtF+Ud2JnNCXTCZ+9ktNdCcgslcuXkDTkFcJNk++MT29yDntDnlF1+jD+uVGumsbw==",
       "requires": {
         "@types/node": "*"
+      },
+      "dependencies": {
+        "@types/node": {
+          "version": "10.9.3",
+          "resolved": "https://registry.npmjs.org/@types/node/-/node-10.9.3.tgz",
+          "integrity": "sha512-DOzWZKUnmFYG0KUOs+9HEBju2QhBU6oM2zeluunQNt0vnJvnkHvtDNlQPZDkTrkC5pZrNx1TPqeL137zciXZMQ=="
+        }
       }
     },
     "adm-zip": {
@@ -122,7 +130,7 @@
     },
     "vsts-fsharp-task-common": {
       "version": "file:../_build/vsts-fsharp-task-common-0.1.0.tgz",
-      "integrity": "sha512-zSvAre/buvNmEE/ovrC7mFS2h4NA/p2CTxApcqGDXUp6GOR46zpw8YUbLrw2xxycMd0yvQQmgGbE856BuRqG5w==",
+      "integrity": "sha512-duuV8x2eRh7shbBTNiEnH1/mJY0STdMFYJy7uQTaVKxeEdtvynT5gEVY+GFCP5zP8kyU6svnbB7aIBQyqoXnPA==",
       "requires": {
         "adm-zip": "^0.4.11",
         "semver": "^5.5.1",

--- a/FAKE5Vault.dev/package-lock.json
+++ b/FAKE5Vault.dev/package-lock.json
@@ -5,7 +5,8 @@
     "@types/node": {
       "version": "7.0.69",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-7.0.69.tgz",
-      "integrity": "sha512-S5NC8HV6HnRipg8nC0j30TPl7ktXjRTKqgyINLNe8K/64UJUI8Lq0sRopXC0hProsV2F5ibj8IqPkl1xpGggrw=="
+      "integrity": "sha512-S5NC8HV6HnRipg8nC0j30TPl7ktXjRTKqgyINLNe8K/64UJUI8Lq0sRopXC0hProsV2F5ibj8IqPkl1xpGggrw==",
+      "dev": true
     },
     "@types/semver": {
       "version": "5.5.0",
@@ -18,6 +19,13 @@
       "integrity": "sha512-5fRLCYhLtDb3hMWqQyH10qtF+Ud2JnNCXTCZ+9ktNdCcgslcuXkDTkFcJNk++MT29yDntDnlF1+jD+uVGumsbw==",
       "requires": {
         "@types/node": "*"
+      },
+      "dependencies": {
+        "@types/node": {
+          "version": "10.9.3",
+          "resolved": "https://registry.npmjs.org/@types/node/-/node-10.9.3.tgz",
+          "integrity": "sha512-DOzWZKUnmFYG0KUOs+9HEBju2QhBU6oM2zeluunQNt0vnJvnkHvtDNlQPZDkTrkC5pZrNx1TPqeL137zciXZMQ=="
+        }
       }
     },
     "adm-zip": {
@@ -122,7 +130,7 @@
     },
     "vsts-fsharp-task-common": {
       "version": "file:../_build/vsts-fsharp-task-common-0.1.0.tgz",
-      "integrity": "sha512-zSvAre/buvNmEE/ovrC7mFS2h4NA/p2CTxApcqGDXUp6GOR46zpw8YUbLrw2xxycMd0yvQQmgGbE856BuRqG5w==",
+      "integrity": "sha512-duuV8x2eRh7shbBTNiEnH1/mJY0STdMFYJy7uQTaVKxeEdtvynT5gEVY+GFCP5zP8kyU6svnbB7aIBQyqoXnPA==",
       "requires": {
         "adm-zip": "^0.4.11",
         "semver": "^5.5.1",

--- a/PaketCredentialCleanup.dev/package-lock.json
+++ b/PaketCredentialCleanup.dev/package-lock.json
@@ -5,7 +5,8 @@
     "@types/node": {
       "version": "7.0.69",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-7.0.69.tgz",
-      "integrity": "sha512-S5NC8HV6HnRipg8nC0j30TPl7ktXjRTKqgyINLNe8K/64UJUI8Lq0sRopXC0hProsV2F5ibj8IqPkl1xpGggrw=="
+      "integrity": "sha512-S5NC8HV6HnRipg8nC0j30TPl7ktXjRTKqgyINLNe8K/64UJUI8Lq0sRopXC0hProsV2F5ibj8IqPkl1xpGggrw==",
+      "dev": true
     },
     "@types/semver": {
       "version": "5.5.0",
@@ -18,6 +19,13 @@
       "integrity": "sha512-5fRLCYhLtDb3hMWqQyH10qtF+Ud2JnNCXTCZ+9ktNdCcgslcuXkDTkFcJNk++MT29yDntDnlF1+jD+uVGumsbw==",
       "requires": {
         "@types/node": "*"
+      },
+      "dependencies": {
+        "@types/node": {
+          "version": "10.9.3",
+          "resolved": "https://registry.npmjs.org/@types/node/-/node-10.9.3.tgz",
+          "integrity": "sha512-DOzWZKUnmFYG0KUOs+9HEBju2QhBU6oM2zeluunQNt0vnJvnkHvtDNlQPZDkTrkC5pZrNx1TPqeL137zciXZMQ=="
+        }
       }
     },
     "adm-zip": {
@@ -122,7 +130,7 @@
     },
     "vsts-fsharp-task-common": {
       "version": "file:../_build/vsts-fsharp-task-common-0.1.0.tgz",
-      "integrity": "sha512-zSvAre/buvNmEE/ovrC7mFS2h4NA/p2CTxApcqGDXUp6GOR46zpw8YUbLrw2xxycMd0yvQQmgGbE856BuRqG5w==",
+      "integrity": "sha512-duuV8x2eRh7shbBTNiEnH1/mJY0STdMFYJy7uQTaVKxeEdtvynT5gEVY+GFCP5zP8kyU6svnbB7aIBQyqoXnPA==",
       "requires": {
         "adm-zip": "^0.4.11",
         "semver": "^5.5.1",

--- a/PaketRestore.dev/package-lock.json
+++ b/PaketRestore.dev/package-lock.json
@@ -3,9 +3,10 @@
   "lockfileVersion": 1,
   "dependencies": {
     "@types/node": {
-      "version": "7.0.27",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-7.0.27.tgz",
-      "integrity": "sha512-2QMiuVOEye2yKmMwE1V96C9HSShmT0WSm6dv2WjacvePEjQNNJGAerTO5hdYhj5lpdK5MW+FVxmyzDhr4omIdw=="
+      "version": "7.0.69",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-7.0.69.tgz",
+      "integrity": "sha512-S5NC8HV6HnRipg8nC0j30TPl7ktXjRTKqgyINLNe8K/64UJUI8Lq0sRopXC0hProsV2F5ibj8IqPkl1xpGggrw==",
+      "dev": true
     },
     "@types/semver": {
       "version": "5.5.0",
@@ -18,6 +19,13 @@
       "integrity": "sha512-5fRLCYhLtDb3hMWqQyH10qtF+Ud2JnNCXTCZ+9ktNdCcgslcuXkDTkFcJNk++MT29yDntDnlF1+jD+uVGumsbw==",
       "requires": {
         "@types/node": "*"
+      },
+      "dependencies": {
+        "@types/node": {
+          "version": "10.9.3",
+          "resolved": "https://registry.npmjs.org/@types/node/-/node-10.9.3.tgz",
+          "integrity": "sha512-DOzWZKUnmFYG0KUOs+9HEBju2QhBU6oM2zeluunQNt0vnJvnkHvtDNlQPZDkTrkC5pZrNx1TPqeL137zciXZMQ=="
+        }
       }
     },
     "adm-zip": {
@@ -26,16 +34,16 @@
       "integrity": "sha512-L8vcjDTCOIJk7wFvmlEUN7AsSb8T+2JrdP7KINBjzr24TJ5Mwj590sLu3BC7zNZowvJWa/JtPmD8eJCzdtDWjA=="
     },
     "balanced-match": {
-      "version": "0.4.2",
-      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.4.2.tgz",
-      "integrity": "sha1-yz8+PHMtwPAe5wtAPzAuYddwmDg="
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
+      "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c="
     },
     "brace-expansion": {
-      "version": "1.1.7",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.7.tgz",
-      "integrity": "sha1-Pv/DxQ4ABTH7cg6v+A8K6O8jz1k=",
+      "version": "1.1.11",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
+      "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
       "requires": {
-        "balanced-match": "^0.4.1",
+        "balanced-match": "^1.0.0",
         "concat-map": "0.0.1"
       }
     },
@@ -63,14 +71,14 @@
       "integrity": "sha1-u+Z0BseaqFxc/sdm/lc0VV36EnQ="
     },
     "q": {
-      "version": "1.5.0",
-      "resolved": "https://registry.npmjs.org/q/-/q-1.5.0.tgz",
-      "integrity": "sha1-3QG6ydBtMObyGa7LglPunr3DCPE="
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/q/-/q-1.5.1.tgz",
+      "integrity": "sha1-fjL3W0E4EpHQRhHxvxQQmsAGUdc="
     },
     "semver": {
-      "version": "5.3.0",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-5.3.0.tgz",
-      "integrity": "sha1-myzl094C0XxgEq0yaqa00M9U+U8="
+      "version": "5.5.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-5.5.1.tgz",
+      "integrity": "sha512-PqpAxfrEhlSUWge8dwIp4tZnQ25DIOthpiaHNIthsjEFQD6EvqUKUDM7L8O2rShkFccYo1VjJR0coWfNkCubRw=="
     },
     "semver-compare": {
       "version": "1.0.0",
@@ -116,13 +124,13 @@
       "integrity": "sha1-Tz+1OxBuYJf8+ctBCfKl6b36UCI="
     },
     "uuid": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.0.1.tgz",
-      "integrity": "sha1-ZUS7ot/ajBzxfmKaOjBeK7H+5sE="
+      "version": "3.3.2",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.3.2.tgz",
+      "integrity": "sha512-yXJmeNaw3DnnKAOKJE51sL/ZaYfWJRl1pK9dr19YFCu0ObS231AB1/LbqTKRAQ5kw8A90rA6fr4riOUpTZvQZA=="
     },
     "vsts-fsharp-task-common": {
       "version": "file:../_build/vsts-fsharp-task-common-0.1.0.tgz",
-      "integrity": "sha512-zSvAre/buvNmEE/ovrC7mFS2h4NA/p2CTxApcqGDXUp6GOR46zpw8YUbLrw2xxycMd0yvQQmgGbE856BuRqG5w==",
+      "integrity": "sha512-duuV8x2eRh7shbBTNiEnH1/mJY0STdMFYJy7uQTaVKxeEdtvynT5gEVY+GFCP5zP8kyU6svnbB7aIBQyqoXnPA==",
       "requires": {
         "adm-zip": "^0.4.11",
         "semver": "^5.5.1",
@@ -130,34 +138,14 @@
         "typed-rest-client": "^1.0.9",
         "vsts-task-lib": "^2.6.0",
         "vsts-task-tool-lib": "^0.10.0"
-      },
-      "dependencies": {
-        "semver": {
-          "version": "5.5.1",
-          "resolved": "https://registry.npmjs.org/semver/-/semver-5.5.1.tgz",
-          "integrity": "sha512-PqpAxfrEhlSUWge8dwIp4tZnQ25DIOthpiaHNIthsjEFQD6EvqUKUDM7L8O2rShkFccYo1VjJR0coWfNkCubRw=="
-        },
-        "vsts-task-lib": {
-          "version": "2.6.0",
-          "resolved": "https://registry.npmjs.org/vsts-task-lib/-/vsts-task-lib-2.6.0.tgz",
-          "integrity": "sha512-ja2qX4BIUvswcNbGtIoGo1SM5mRVc3Yaf7oM4oY64bNHs04chKfvH6f3cDDG0pd44OrZIGQE9LgECzeau6z2wA==",
-          "requires": {
-            "minimatch": "3.0.4",
-            "mockery": "^1.7.0",
-            "q": "^1.1.2",
-            "semver": "^5.1.0",
-            "shelljs": "^0.3.0",
-            "uuid": "^3.0.1"
-          }
-        }
       }
     },
     "vsts-task-lib": {
-      "version": "2.0.5",
-      "resolved": "https://registry.npmjs.org/vsts-task-lib/-/vsts-task-lib-2.0.5.tgz",
-      "integrity": "sha1-y9WrIy6rtxDJaXkFMYcmlZHA1RA=",
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/vsts-task-lib/-/vsts-task-lib-2.6.0.tgz",
+      "integrity": "sha512-ja2qX4BIUvswcNbGtIoGo1SM5mRVc3Yaf7oM4oY64bNHs04chKfvH6f3cDDG0pd44OrZIGQE9LgECzeau6z2wA==",
       "requires": {
-        "minimatch": "^3.0.0",
+        "minimatch": "3.0.4",
         "mockery": "^1.7.0",
         "q": "^1.1.2",
         "semver": "^5.1.0",

--- a/SetPaketCredentialProvider.dev/package-lock.json
+++ b/SetPaketCredentialProvider.dev/package-lock.json
@@ -3,9 +3,10 @@
   "lockfileVersion": 1,
   "dependencies": {
     "@types/node": {
-      "version": "7.0.27",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-7.0.27.tgz",
-      "integrity": "sha512-2QMiuVOEye2yKmMwE1V96C9HSShmT0WSm6dv2WjacvePEjQNNJGAerTO5hdYhj5lpdK5MW+FVxmyzDhr4omIdw=="
+      "version": "7.0.69",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-7.0.69.tgz",
+      "integrity": "sha512-S5NC8HV6HnRipg8nC0j30TPl7ktXjRTKqgyINLNe8K/64UJUI8Lq0sRopXC0hProsV2F5ibj8IqPkl1xpGggrw==",
+      "dev": true
     },
     "@types/semver": {
       "version": "5.5.0",
@@ -18,6 +19,13 @@
       "integrity": "sha512-5fRLCYhLtDb3hMWqQyH10qtF+Ud2JnNCXTCZ+9ktNdCcgslcuXkDTkFcJNk++MT29yDntDnlF1+jD+uVGumsbw==",
       "requires": {
         "@types/node": "*"
+      },
+      "dependencies": {
+        "@types/node": {
+          "version": "10.9.3",
+          "resolved": "https://registry.npmjs.org/@types/node/-/node-10.9.3.tgz",
+          "integrity": "sha512-DOzWZKUnmFYG0KUOs+9HEBju2QhBU6oM2zeluunQNt0vnJvnkHvtDNlQPZDkTrkC5pZrNx1TPqeL137zciXZMQ=="
+        }
       }
     },
     "adm-zip": {
@@ -122,7 +130,7 @@
     },
     "vsts-fsharp-task-common": {
       "version": "file:../_build/vsts-fsharp-task-common-0.1.0.tgz",
-      "integrity": "sha512-zSvAre/buvNmEE/ovrC7mFS2h4NA/p2CTxApcqGDXUp6GOR46zpw8YUbLrw2xxycMd0yvQQmgGbE856BuRqG5w==",
+      "integrity": "sha512-duuV8x2eRh7shbBTNiEnH1/mJY0STdMFYJy7uQTaVKxeEdtvynT5gEVY+GFCP5zP8kyU6svnbB7aIBQyqoXnPA==",
       "requires": {
         "adm-zip": "^0.4.11",
         "semver": "^5.5.1",

--- a/build.fsx
+++ b/build.fsx
@@ -274,6 +274,8 @@ Target.create "Bundle" (fun _ ->
     // delete stuff we don't want
 
     Npm.script "." "tfx" ["extension"; "create"; "--manifest-globs"; "vss-extension.json"]
+    Npm.script "." "tfx" ["extension"; "create"; "--manifest-globs"; "ext-fake.json"]
+    Npm.script "." "tfx" ["extension"; "create"; "--manifest-globs"; "ext-paket.json"]
 )
 
 Target.create "Default" (fun _ -> ())

--- a/ext-fake.json
+++ b/ext-fake.json
@@ -1,0 +1,41 @@
+{
+    "manifestVersion": 1,
+    "id": "fake-build",
+    "version": "1.0.0",
+    "name": "FAKE Build & Release Tasks for VSTS",
+    "publisher": "IsaacAbraham",
+    "targets": [ { "id": "Microsoft.VisualStudio.Services" } ],
+    "description": "Automate your build and release process alongside your code with the power of .NET",
+    "public":  true,
+    "categories": [ "Build and release" ],
+    "icons": { "default": "FAKE5.dev\\icon.png" },
+    "tags": [ "F#", "FAKE", "FAKE5", "Build", "Release", "Automation", "Scripting" ],
+    "screenshots": [
+        { "path": "content\\images\\1.png" },
+        { "path": "content\\images\\2.png" }
+    ],
+    "content": { "details": { "path": "readme.md" } },
+    "links" : {
+        "support": { "uri": "https://github.com/isaacabraham/vsts-fsharp" }
+    },
+    "branding": {
+        "color": "rgb(51,51,51)",
+        "theme": "dark"
+    },
+    "files": [
+        { "path": "FAKE5" },
+        { "path": "FAKE5Vault" }
+    ],
+    "contributions": [
+        {   "id": "26d2a628-d5fe-4d5a-943d-33c78b2d76f3",
+            "type": "ms.vss-distributed-task.task",
+            "targets": [ "ms.vss-distributed-task.tasks" ],
+            "properties": { "name": "FAKE5Vault" }
+        },
+        {   "id": "a2dadf20-1a83-4220-a4ee-b52f6c77f3cf",
+            "type": "ms.vss-distributed-task.task",
+            "targets": [ "ms.vss-distributed-task.tasks" ],
+            "properties": { "name": "FAKE5" }
+        }
+    ]
+}

--- a/ext-paket.json
+++ b/ext-paket.json
@@ -1,0 +1,47 @@
+{
+    "manifestVersion": 1,
+    "id": "paket",
+    "version": "1.0.0",
+    "name": "Paket Tasks for VSTS",
+    "publisher": "IsaacAbraham",
+    "targets": [ { "id": "Microsoft.VisualStudio.Services" } ],
+    "description": "Manage your NuGet packages with the paket client.",
+    "public":  true,
+    "categories": [ "Build and release" ],
+    "icons": { "default": "PaketRestore.dev\\icon.png" },
+    "tags": [ "F#", "Paket", "NuGet", "Packages", "Paket" ],
+    "screenshots": [
+        { "path": "content\\images\\1.png" },
+        { "path": "content\\images\\2.png" }
+    ],
+    "content": { "details": { "path": "readme.md" } },
+    "links" : {
+        "support": { "uri": "https://github.com/isaacabraham/vsts-fsharp" }
+    },
+    "branding": {
+        "color": "rgb(51,51,51)",
+        "theme": "dark"
+    },
+    "files": [
+        { "path": "PaketRestore" },
+        { "path": "SetPaketCredentialProvider" },
+        { "path": "PaketCredentialCleanup" }
+    ],
+    "contributions": [
+        {   "id": "1ba72b0a-f476-4a91-90a0-b8e7a0cc4338",
+            "type": "ms.vss-distributed-task.task",
+            "targets": [ "ms.vss-distributed-task.tasks" ],
+            "properties": { "name": "PaketRestore" }
+        },
+        {   "id": "5bfdd7ca-9bf4-40f7-b753-fd674e7ff85c",
+            "type": "ms.vss-distributed-task.task",
+            "targets": [ "ms.vss-distributed-task.tasks" ],
+            "properties": { "name": "SetPaketCredentialProvider" }
+        },
+        {   "id": "33416f37-5fe8-488d-a2aa-48f52e7a14f9",
+            "type": "ms.vss-distributed-task.task",
+            "targets": [ "ms.vss-distributed-task.tasks" ],
+            "properties": { "name": "PaketCredentialCleanup" }
+        }
+    ]
+}


### PR DESCRIPTION
Adds a "Fake" and "Paket" extension alongside the "all-in-one" extension.
It's surprisingly simple to package a task into multiple extension. The question is if this leads to problems when multiple extensions contain the same task. Something left to test... I think I will add another round of extensions without `public: true` (which is the currently suggested official solution) and test on my instance.